### PR TITLE
Replaced Error with \Exception

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -49,7 +49,7 @@ class Util
     {
         preg_match("/^\"(.*)\"/", $literal, $match); //TODO: somehow the copied regex did not work. To be checked. Contained [^]
         if (empty($match)) {
-            throw new Error($literal + ' is not a literal');
+            throw new \Exception($literal + ' is not a literal');
         }
         return $match[1];
     }
@@ -58,7 +58,7 @@ class Util
     {
         preg_match('/^".*"(?:\^\^([^"]+)|(@)[^@"]+)?$/',$literal,$match);//TODO: somehow the copied regex did not work. To be checked. Contained [^] instead of the .
         if (empty($match))
-            throw new Error($literal + ' is not a literal');
+            throw new \Exception($literal + ' is not a literal');
         if (!empty($match[1])) {
             return $match[1];
         } else {
@@ -72,7 +72,7 @@ class Util
     {
         preg_match('/^".*"(?:@([^@"]+)|\^\^[^"]+)?$/', $literal, $match);
         if (empty($match))
-            throw new Error($literal + ' is not a literal');
+            throw new \Exception($literal + ' is not a literal');
         return isset($match[1]) ? strtolower($match[1]) : '';
     }
             


### PR DESCRIPTION
Because PHP can't found a class named `Error` in this repository. I guess, its from JavaScript and the developers meant `\Exception`.

If i want to use some Util function and insert bad data, the following error appears:

```
Fatal error: Class 'pietercolpaert\hardf\Error' not found in /app/src/Saft/Addition/hardf/vendor/pietercolpaert/hardf/src/Util.php on line 75

Call Stack:
    0.0002     227376   1. {main}() /app/src/Saft/Addition/hardf/vendor/phpunit/phpunit/phpunit:0
    0.0035     741280   2. PHPUnit_TextUI_Command::main() /app/src/Saft/Addition/hardf/vendor/phpunit/phpunit/phpunit:52
    0.0035     741904   3. PHPUnit_TextUI_Command->run() /app/src/Saft/Addition/hardf/vendor/phpunit/phpunit/src/TextUI/Command.php:100
    0.0914    4911888   4. PHPUnit_TextUI_TestRunner->doRun() /app/src/Saft/Addition/hardf/vendor/phpunit/phpunit/src/TextUI/Command.php:149
    0.0963    5106256   5. PHPUnit_Framework_TestSuite->run() /app/src/Saft/Addition/hardf/vendor/phpunit/phpunit/src/TextUI/TestRunner.php:440
    0.1020    5327200   6. PHPUnit_Framework_TestSuite->run() /app/src/Saft/Addition/hardf/vendor/phpunit/phpunit/src/Framework/TestSuite.php:722
    0.1055    5340800   7. PHPUnit_Framework_TestCase->run() /app/src/Saft/Addition/hardf/vendor/phpunit/phpunit/src/Framework/TestSuite.php:722
    0.1055    5340800   8. PHPUnit_Framework_TestResult->run() /app/src/Saft/Addition/hardf/vendor/phpunit/phpunit/src/Framework/TestCase.php:724
    0.1056    5341808   9. PHPUnit_Framework_TestCase->runBare() /app/src/Saft/Addition/hardf/vendor/phpunit/phpunit/src/Framework/TestResult.php:612
    0.1057    5363832  10. PHPUnit_Framework_TestCase->runTest() /app/src/Saft/Addition/hardf/vendor/phpunit/phpunit/src/Framework/TestCase.php:768
    0.1058    5364672  11. ReflectionMethod->invokeArgs() /app/src/Saft/Addition/hardf/vendor/phpunit/phpunit/src/Framework/TestCase.php:909
    0.1058    5365296  12. Saft\Data\Test\ParserAbstractTest->testParseStreamToIteratorTurtleFile() /app/src/Saft/Addition/hardf/vendor/phpunit/phpunit/src/Framework/TestCase.php:909
    0.1058    5367112  13. Saft\Addition\hardf\Data\ParserHardf->parseStreamToIterator() /app/src/Saft/Addition/hardf/vendor/saft/saft-data/Test/ParserAbstractTest.php:44
    0.1061    5368240  14. Saft\Addition\hardf\Data\ParserHardf->parseStringToIterator() /app/src/Saft/Addition/hardf/Data/ParserHardf.php:182
    0.1169    5961656  15. pietercolpaert\hardf\Util::getLiteralLanguage() /app/src/Saft/Addition/hardf/Data/ParserHardf.php:147
```