### PR TITLE
Util.php: added s option to regex in getLiteralType and getLiteralLanguage

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -56,7 +56,7 @@ class Util
     // Gets the type of a literal in the N3 library
     public static function getLiteralType ($literal)
     {
-        preg_match('/^".*"(?:\^\^([^"]+)|(@)[^@"]+)?$/',$literal,$match);//TODO: somehow the copied regex did not work. To be checked. Contained [^] instead of the .
+        preg_match('/^".*"(?:\^\^([^"]+)|(@)[^@"]+)?$/s',$literal,$match);//TODO: somehow the copied regex did not work. To be checked. Contained [^] instead of the .
         if (empty($match))
             throw new \Exception($literal + ' is not a literal');
         if (!empty($match[1])) {
@@ -70,7 +70,7 @@ class Util
     // Gets the language of a literal in the N3 library
     public static function getLiteralLanguage ($literal)
     {
-        preg_match('/^".*"(?:@([^@"]+)|\^\^[^"]+)?$/', $literal, $match);
+        preg_match('/^".*"(?:@([^@"]+)|\^\^[^"]+)?$/s', $literal, $match);
         if (empty($match))
             throw new \Exception($literal + ' is not a literal');
         return isset($match[1]) ? strtolower($match[1]) : '';

--- a/test/UtilTest.php
+++ b/test/UtilTest.php
@@ -151,8 +151,18 @@ class UtilTest extends PHPUnit_Framework_TestCase
         //it('does not work with null', function () {
         //TODO: Util::getLiteralType.bind(null, null).should.throw('null is not a literal');
 
-    }    
-  
+    }
+
+    // tests getLiteralType if multi line string was given (check for adaption of Util.php,
+    // adding an s to the regex)
+    public function testGetLiteralTypeMultilineString()
+    {
+        $literal = '"This document is published by the Provenance Working Group (http://www.w3.org/2011/prov/wiki/Main_Page).
+
+If you wish to make comments regarding this document, please send them to public-prov-comments@w3.org (subscribe public-prov-comments-request@w3.org, archives http://lists.w3.org/Archives/Public/public-prov-comments/). All feedback is welcome."^^<http://>';
+
+        $this->assertEquals('<http://>', Util::getLiteralType($literal));
+    }
 
     public function testGetLiteralLanguage () {
         //it('gets the language of a literal', function () {
@@ -188,9 +198,19 @@ class UtilTest extends PHPUnit_Framework_TestCase
     
 
         //it('does not work with null', function () {
-        //TODO: Util::getLiteralLanguage.bind(null, null).should.throw('null is not a literal');    
+        //TODO: Util::getLiteralLanguage.bind(null, null).should.throw('null is not a literal');
     }
- 
+
+    // tests getLiteralLanguage if multi line string was given (check for adaption of Util.php,
+    // adding an s to the regex)
+    public function testGetLiteralLanguageMultilineString()
+    {
+        $literal = '"This document is published by the Provenance Working Group (http://www.w3.org/2011/prov/wiki/Main_Page).
+
+If you wish to make comments regarding this document, please send them to public-prov-comments@w3.org (subscribe public-prov-comments-request@w3.org, archives http://lists.w3.org/Archives/Public/public-prov-comments/). All feedback is welcome."@en';
+
+        $this->assertEquals('en', Util::getLiteralLanguage($literal));
+    }
 
     public function testIsPrefixedName () {
         //it('matches a prefixed name', function () {


### PR DESCRIPTION
Before that fix, certain multi line strings could not be processed.

Example string which would have fail:

```
"This document is published by the Provenance Working Group
(http://www.w3.org/2011/prov/wiki/Main_Page).

If you wish to make comments regarding this document, please send them to
public-prov-comments@w3.org (subscribe public-prov-comments-request@w3.org,
archives http://lists.w3.org/Archives/Public/public-prov-comments/). All
feedback is welcome."^^<http://>
```