### PR TITLE
fixes #33 (Util::getLiteralValue() fails for multiline values)

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -61,7 +61,7 @@ class Util
      */
     public static function getLiteralValue(string $literal)
     {
-        preg_match('/^"(.*)"/', $literal, $match); //TODO: somehow the copied regex did not work. To be checked. Contained [^]
+        preg_match('/^"(.*)"/s', $literal, $match); //TODO: somehow the copied regex did not work. To be checked. Contained [^]
         if (empty($match)) {
             throw new \Exception($literal.' is not a literal');
         }

--- a/test/UtilTest.php
+++ b/test/UtilTest.php
@@ -99,6 +99,8 @@ class UtilTest extends TestCase
         // it gets the value of a literal with a cariage return
         $this->assertEquals('Mickey\rMouse', Util::getLiteralValue('"Mickey\rMouse"'));
 
+        $this->assertEquals("foo\nbar", Util::getLiteralValue('"' . "foo\nbar" . '"'));
+
         // it does not work with non-literals
         //TODO: Util::getLiteralValue.bind(null, 'http://ex.org/').should.throw('http://ex.org/ is not a literal');
 


### PR DESCRIPTION
Fixes #33

CC @pietercolpaert OK with you?

Thanks @zozlak for reporting it and providing a fix!