### PR TITLE
N3Lexer: allow typeIRI tokens in line mode (closes #32)

### DIFF
--- a/src/N3Lexer.php
+++ b/src/N3Lexer.php
@@ -52,7 +52,7 @@ class N3Lexer
             $this->_tokenize = function ($input, $finalize = true) use ($self) {
                 $tokens = \call_user_func($this->_oldTokenize, $input, $finalize);
                 foreach ($tokens as $token) {
-                    if (!preg_match('/^(?:IRI|prefixed|literal|langcode|type|\.|eof)$/', $token['type'])) {
+                    if (!preg_match('/^(?:IRI|prefixed|literal|langcode|type|typeIRI|\.|eof)$/', $token['type'])) {
                         throw $self->syntaxError($token['type'], $token['line']);
                     }
                 }

--- a/src/N3Lexer.php
+++ b/src/N3Lexer.php
@@ -52,7 +52,7 @@ class N3Lexer
             $this->_tokenize = function ($input, $finalize = true) use ($self) {
                 $tokens = \call_user_func($this->_oldTokenize, $input, $finalize);
                 foreach ($tokens as $token) {
-                    if (!preg_match('/^(?:IRI|prefixed|literal|langcode|type|typeIRI|\.|eof)$/', $token['type'])) {
+                    if (!preg_match('/^(?:blank|IRI|prefixed|literal|langcode|type|typeIRI|\.|eof)$/', $token['type'])) {
                         throw $self->syntaxError($token['type'], $token['line']);
                     }
                 }

--- a/test/TriGParserTest.php
+++ b/test/TriGParserTest.php
@@ -1213,7 +1213,7 @@ c:test <b> "c:テスト" .', ['http://example.org/test', 'b', '"c:テスト"', '
 
     public function testNTriplesFormat(): void
     {
-        $parser = function () { return new TriGParser(['format' => 'N-Triples']); };
+        $parser = function () { return new TriGParser(['format' => 'N-Triples', 'blankNodePrefix' => '']); };
 
         // should parse a single triple
         $this->shouldParse($parser, '<http://ex.org/a> <http://ex.org/b> "c".',
@@ -1247,6 +1247,10 @@ c:test <b> "c:テスト" .', ['http://example.org/test', 'b', '"c:テスト"', '
         // https://github.com/pietercolpaert/hardf/issues/32
         $this->shouldParse($parser, '<http://a.example/s> <http://a.example/p> "1"^^<http://www.w3.org/2001/XMLSchema#integer> .',
         ['http://a.example/s', 'http://a.example/p', '"1"^^http://www.w3.org/2001/XMLSchema#integer']);
+
+        // https://github.com/pietercolpaert/hardf/issues/34
+        $this->shouldParse($parser, '_:r1 <https://foo.bar> "baz".',
+        ['_:r1', 'https://foo.bar', '"baz"']);
     }
 
     public function testNQuadsFormat(): void

--- a/test/TriGParserTest.php
+++ b/test/TriGParserTest.php
@@ -32,6 +32,8 @@ class TriGParserTest extends TestCase
             //expect($error).not.to.exist;
             if ($triple) {
                 $results[] = $triple;
+            } elseif ($error) {
+                throw $error;
             } else {
                 $this->assertEquals(self::toSortedJSON($items), self::toSortedJSON($results));
             }
@@ -1241,6 +1243,10 @@ c:test <b> "c:テスト" .', ['http://example.org/test', 'b', '"c:テスト"', '
 
         // should not parse a formula as object
         $this->shouldNotParse($parser, '<urn:a:a> <urn:b:b> {}.', 'Unexpected "{" on line 1.');
+
+        // https://github.com/pietercolpaert/hardf/issues/32
+        $this->shouldParse($parser, '<http://a.example/s> <http://a.example/p> "1"^^<http://www.w3.org/2001/XMLSchema#integer> .',
+        ['http://a.example/s', 'http://a.example/p', '"1"^^http://www.w3.org/2001/XMLSchema#integer']);
     }
 
     public function testNQuadsFormat(): void


### PR DESCRIPTION
Typed literals are perfectly valid in n-triples and n-quads - see https://www.w3.org/TR/n-triples/#grammar-production-literal and https://www.w3.org/TR/n-quads/#grammar-production-literal