### PR TITLE
phpunit.yml: extend workflow to run for all supported PHP versions (7.1 - 8.3)

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Adding Github Action to run PHPUnit was a good move @pietercolpaert

I extended it so it runs our tests for each major PHP version (7.1-8.3), even though versions prior 8.0 are EOL (source: https://www.php.net/supported-versions.php).