### PR TITLE
Add PHP 8.4 and 8.5 to PHPUnit workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
hardf does already fully supports PHP 8.4 and 8.5 so there is nothing further to do here :rocket:

Tests show no deprecation / warnings:

<img width="930" height="269" alt="image" src="https://github.com/user-attachments/assets/027d2ef0-dc5c-423c-ab7e-5d2761fbb75e" />

<img width="921" height="265" alt="Bildschirmfoto vom 2025-10-03 13-02-49" src="https://github.com/user-attachments/assets/f5fa92c3-fcdd-4799-b611-612b8f352e45" />

