### PR TITLE
New test for performance optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# The Hardf RDF 1.2 Turtle, N-Triples, N-Quads, and TriG parser for PHP
+# The Hardf RDF1.2 Turtle, N-Triples, N-Quads, and TriG parser for PHP
 
 [![PHP CI](https://github.com/pietercolpaert/hardf/actions/workflows/php-ci.yml/badge.svg)](https://github.com/pietercolpaert/hardf/actions/workflows/php-ci.yml)
 [![W3C RDF1.2 spec compliance](https://github.com/pietercolpaert/hardf/actions/workflows/spec-compliance.yml/badge.svg)](https://github.com/pietercolpaert/hardf/actions/workflows/spec-compliance.yml)
 [![Latest stable release](https://img.shields.io/packagist/v/pietercolpaert/hardf)](https://packagist.org/packages/pietercolpaert/hardf)
 
-**Hardf** is a PHP 7.1+ library that lets you handle Linked Data (RDF 1.2). It offers [**parsing**](#parsing) from and [**writing**](#writing) in [Turtle](http://www.w3.org/TR/turtle/), [TriG](http://www.w3.org/TR/trig/), [N-Triples](http://www.w3.org/TR/n-triples/), and [N-Quads](http://www.w3.org/TR/n-quads/). Both the parser and the serializer have _streaming_ support.
+**Hardf** is a PHP 7.1+ library that lets you handle Linked Data (RDF1.2). It offers [**parsing**](#parsing) from and [**writing**](#writing) in [Turtle](http://www.w3.org/TR/turtle/), [TriG](http://www.w3.org/TR/trig/), [N-Triples](http://www.w3.org/TR/n-triples/), and [N-Quads](http://www.w3.org/TR/n-quads/). Both the parser and the serializer have _streaming_ support.
 
-Hardf also supports [RDF 1.2](https://www.w3.org/TR/rdf12-concepts/) features that are relevant to this representation, including triple terms, reified triples, annotation syntax, directional language literals, `VERSION` declarations, and [RDF Messages](https://w3c-cg.github.io/rsp/spec/messages). Conformances is [tested using the official test suites](#rdf-working-group-test-suites).
+Hardf also supports [RDF1.2](https://www.w3.org/TR/rdf12-concepts/) features that are relevant to this representation, including triple terms, reified triples, annotation syntax, directional language literals, `VERSION` declarations, and [RDF Messages](https://w3c-cg.github.io/rsp/spec/messages). Conformances is [tested using the official test suites](#rdf-working-group-test-suites).
 
 This library was started as a port of [N3.js](https://github.com/rdfjs/N3.js/tree/v0.10.0) to PHP.
 
@@ -33,7 +33,7 @@ Encode literals as follows (similar to N3.js):
 '"1"^^http://www.w3.org/2001/XMLSchema#integer' // no angular brackets <>
 ```
 
-RDF 1.2 triple terms are represented as structured arrays, not as serialized strings:
+RDF1.2 triple terms are represented as structured arrays, not as serialized strings:
 
 ```php
 $tripleTerm = [
@@ -161,7 +161,7 @@ MESSAGE
 
 Next to [TriG](https://www.w3.org/TR/trig/), the TriGParser class also parses [Turtle](https://www.w3.org/TR/turtle/), [N-Triples](https://www.w3.org/TR/n-triples/), and [N-Quads](https://www.w3.org/TR/n-quads/).
 
-RDF 1.2 triple terms are emitted as arrays with `type => TripleTerm`. Reified triple syntax emits an `rdf:reifies` triple whose object is such a triple term.
+RDF1.2 triple terms are emitted as arrays with `type => TripleTerm`. Reified triple syntax emits an `rdf:reifies` triple whose object is such a triple term.
 
 RDF Message Logs are enabled by a `VERSION` label with the `-messages` suffix, such as `VERSION "1.2-messages"`. When parsing in streaming mode, the triple callback receives the current message counter as its fourth argument. Blank node labels are scoped per message, so the same blank node labels may legally reappear in later messages.
 
@@ -225,7 +225,7 @@ $parser->parse("<http://A> <https://B> <http://C> <http://G> . <A2> <https://B2>
 });
 ```
 
-Parsing RDF 1.2 triple terms:
+Parsing RDF1.2 triple terms:
 
 ```php
 $parser = new TriGParser();
@@ -324,6 +324,8 @@ $messages = $parser->parse(
   * contains `n3`, e.g. `n3` - [N3](https://www.w3.org/TeamSubmission/n3/)
 * `blankNodePrefix` (defaults to `b0_`) prefix forced on blank node names, e.g. `TriGParser(["blankNodePrefix" => 'foo'])` will parse `_:bar` as `_:foobar`.
 * `documentIRI` sets the base URI used to resolve relative URIs (not applicable if `format` indicates n-triples or n-quads)
+* `relax` enables the relaxed N-Triples/N-Quads hot path for trusted benchmark input. Keep this disabled for conformance tests.
+* `namedNodeCacheSize` sets the bounded cache size for recurring named nodes in the relaxed N-Triples/N-Quads hot path, such as predicates, datatypes, and graph IRIs. Defaults to `2048`.
 * `lexer` allows usage of your own lexer class. A lexer must provide the following public methods:
   * `tokenize(string $input, bool $finalize = true): array<array{'subject': string, 'predicate': string, 'object': string, 'graph': string}>`
   * `tokenizeChunk(string $input): array<array{'subject': string, 'predicate': string, 'object': string, 'graph': string}>`
@@ -392,7 +394,7 @@ curl -H "accept: application/trig" http://fragments.dbpedia.org/2015/en | php bi
 
 ## RDF Working Group Test Suites
 
-The official RDF Working Group test manifests live in [`w3c/rdf-tests`](https://github.com/w3c/rdf-tests). RDF 1.2 manifests are available under [`rdf/rdf12`](https://github.com/w3c/rdf-tests/tree/main/rdf/rdf12), including Turtle, TriG, N-Triples, and N-Quads suites.
+The official RDF Working Group test manifests live in [`w3c/rdf-tests`](https://github.com/w3c/rdf-tests). RDF1.2 manifests are available under [`rdf/rdf12`](https://github.com/w3c/rdf-tests/tree/main/rdf/rdf12), including Turtle, TriG, N-Triples, and N-Quads suites.
 
 This repository includes an optional [`rdf-test-suite.js`](https://github.com/rubensworks/rdf-test-suite.js) bridge in `spec/`. The JavaScript runner loads the W3C manifests, and `spec/hardf-rdf-test-engine.js` delegates parsing to `spec/hardf-rdf-test-parser.php`.
 
@@ -402,7 +404,7 @@ Install the optional Node dependencies:
 npm install
 ```
 
-Run individual RDF 1.2 leaf manifests:
+Run individual RDF1.2 leaf manifests:
 
 ```bash
 npm run rdf12:ntriples:syntax
@@ -430,68 +432,53 @@ npm run rdf12:turtle:eval:earl
 npm run rdf11:trig:earl
 ```
 
-All RDF 1.2 compliance commands pass. The RDF 1.2 root manifests also include C14N tests, but `rdf-test-suite.js` does not currently provide handlers for the RDF 1.2 C14N test types.
+All RDF1.2 compliance commands pass. The RDF1.2 root manifests also include C14N tests, but `rdf-test-suite.js` does not currently provide handlers for the RDF1.2 C14N test types.
 
 RDF/XML and RDF semantics manifests are not wired because hardf does not implement RDF/XML parsing or entailment. The compliance scripts in this repository therefore focus on the RDF parser manifests for Turtle, TriG, N-Triples, and N-Quads.
 
 ## Performance
 
-In the PHP ecosystem, Hardf is the only library here that supports RDF 1.1 and RDF 1.2 features such as named graphs and triple terms. EasyRDF and ARC2 are still useful comparison points, but they do not cover that full feature set.
+In the PHP ecosystem, Hardf is the only parser in this benchmark that supports the full feature set tested here: RDF 1.1 plus RDF1.2 features such as named graphs and triple terms. EasyRDF and ARC2 are useful comparison points for plain RDF1.0-compatible N-Triples, but they are not like-for-like RDF1.2 comparisons.
 
-Because of that, the benchmark below uses a generated **N-Triples** dataset, not TriG. The input is generated through Hardf's own `TriGWriter` in `N-Triples` mode and contains only plain triples, with a mix of IRI objects, literal objects, and occasional blank nodes. This gives all compared parsers the same RDF 1.0-compatible input while still reflecting realistic parser work.
+Strict parsing keeps the full conformance parser path. A strict scanner prototype was measured, but its validation overhead was slower than the existing parser path on PHP 8.3. For trusted machine-generated N-Triples and N-Quads input, the `relax` option enables a single-pass scanner hot path. The relaxed scanner keeps input as strings, scans by byte offset, emits quads immediately for streaming callbacks, buffers only incomplete trailing lines, and falls back to the general parser when it sees escapes, unsupported syntax, comments, or unusual whitespace. Spec-test paths run in strict mode.
 
-The measurements below were taken with PHP 8.3.6 and Node.js 25.9.0 using `php perf/compare-hardf-n3js.php`. EasyRDF and ARC2 were measured with CLI opcache enabled. Hardf was measured both with and without CLI opcache enabled. N3.js is included as a reference implementation on a very fast runtime, so it is expected to win on absolute throughput.
+The benchmark generates datasets at $10^4$, $10^5$, and $10^6$ statements and reports elapsed time plus statements/second. The RDF1.2 dataset includes default-graph triples, named-graph quads, IRI objects, string literals, language-tagged literals, integer/decimal/boolean literals, and triple terms. EasyRDF and ARC2 comparisons are limited to a plain RDF1.0-compatible N-Triples dataset.
 
 ```bash
-# Run the default comparison (Hardf vs N3.js)
-php perf/compare-hardf-n3js.php
+# Quick benchmark, useful before committing
+npm run bench:rdf:quick
 
-# Also include EasyRDF and ARC2
-php perf/compare-hardf-n3js.php --all
+# Full benchmark
+npm run bench:rdf
 ```
 
-The script generates synthetic N-Triples datasets at `/tmp/hardf-perf/` and reports parse time and memory for each framework.
+CLI benchmarks run with `opcache.enable_cli=1` and JIT disabled (`opcache.jit_buffer_size=0`) for reproducibility.
 
-That expectation does show up in the results, but the interesting part is the size of the gap: Hardf remains within a single-digit factor of N3.js across the whole range and scales roughly linearly from $10^5$ to $10^7$ triples. CLI opcache helps Hardf modestly on runtime and significantly on reported PHP memory. EasyRDF and ARC2 fall further behind as the data grows.
+The measurements below were taken on 2026-06-06 with PHP 8.3.6 CLI by running `npm run bench:rdf`.
 
-We report on the findings for increasing number of triples.
+| dataset | parser | statements | elapsed ms | statements/sec |
+|---------|--------|-----------:|-----------:|---------------:|
+| RDF1.2 mixed N-Quads | Hardf strict | 10,000 | 68.21 | 146,602 |
+| RDF1.2 mixed N-Quads | Hardf relax | 10,000 | 25.72 | 388,876 |
+| Plain RDF1.0 N-Triples | Hardf strict | 10,000 | 48.97 | 204,216 |
+| Plain RDF1.0 N-Triples | EasyRDF | 10,000 | 30.48 | 328,126 |
+| Plain RDF1.0 N-Triples | ARC2 | 10,000 | 125.48 | 79,691 |
+| RDF1.2 mixed N-Quads | Hardf strict | 100,000 | 664.83 | 150,415 |
+| RDF1.2 mixed N-Quads | Hardf relax | 100,000 | 223.27 | 447,882 |
+| Plain RDF1.0 N-Triples | Hardf strict | 100,000 | 461.03 | 216,905 |
+| Plain RDF1.0 N-Triples | EasyRDF | 100,000 | 354.94 | 281,738 |
+| Plain RDF1.0 N-Triples | ARC2 | 100,000 | 1,287.55 | 77,667 |
+| RDF1.2 mixed N-Quads | Hardf strict | 1,000,000 | 6,647.96 | 150,422 |
+| RDF1.2 mixed N-Quads | Hardf relax | 1,000,000 | 2,226.82 | 449,072 |
+| Plain RDF1.0 N-Triples | Hardf strict | 1,000,000 | 4,770.10 | 209,639 |
+| Plain RDF1.0 N-Triples | EasyRDF | 1,000,000 | 4,639.85 | 215,524 |
+| Plain RDF1.0 N-Triples | ARC2 | 1,000,000 | 13,689.83 | 73,047 |
 
-Note that the memory figures are runtime-specific and therefore not perfectly comparable across languages: PHP reports `memory_get_usage()`, while Node.js reports V8 `heapUsed`. The timing results are the more meaningful cross-runtime comparison.
+The main result is that strict RDF1.2 parsing remains stable and linear while preserving conformance. On the mixed RDF1.2 N-Quads dataset, Hardf strict reaches about $1.5 \times 10^5$ statements/second at $10^6$ statements. The relaxed scanner reaches about $4.5 \times 10^5$ statements/second on the same generated dataset, roughly `3.0x` faster than strict mode.
 
+The plain RDF1.0 N-Triples benchmark isolates simple line-based triples. In that dataset, Hardf strict reaches about $2.1 \times 10^5$ statements/second at $10^6$ statements, close to EasyRDF on the same RDF1.0-only input and about `2.9x` faster than ARC2. This comparison should not be extrapolated to RDF1.2 support, because the RDF1.2 benchmark includes named graphs and triple terms that EasyRDF and ARC2 do not cover here.
 
-For __100,000 triples__:
-
-| framework | time (ms) | memory (MB) | slower than N3.js |
-|-----------|----------:|------------:|------------------:|
-| __Hardf__ without opcache | 382 | 1.849 | 3.41x |
-| __Hardf__ with opcache | 372 | 0.540 | 3.32x |
-| [EasyRDF](https://github.com/easyrdf/easyrdf) with opcache | 303 | 181.346 | 2.71x |
-| [ARC2](https://github.com/semsol/arc2) with opcache | 1,133 | 83.435 | 10.12x |
-| [N3.js](https://github.com/rdfjs/N3.js) | 112 | 6.328 | 1.00x |
-
-For __1,000,000 triples__:
-
-| framework | time (ms) | memory (MB) | slower than N3.js |
-|-----------|----------:|------------:|------------------:|
-| __Hardf__ without opcache | 3,961 | 1.849 | 4.62x |
-| __Hardf__ with opcache | 3,880 | 0.540 | 4.52x |
-| [EasyRDF](https://github.com/easyrdf/easyrdf) with opcache | 4,247 | 1,788.624 | 4.95x |
-| [ARC2](https://github.com/semsol/arc2) with opcache | 12,463 | 826.056 | 14.53x |
-| [N3.js](https://github.com/rdfjs/N3.js) | 858 | 9.263 | 1.00x |
-
-For __10,000,000 triples__:
-
-| framework | time (ms) | memory (MB) | slower than N3.js |
-|-----------|----------:|------------:|------------------:|
-| __Hardf__ without opcache | 41,607 | 1.849 | 5.19x |
-| __Hardf__ with opcache | 39,098 | 0.540 | 4.88x |
-| [EasyRDF](https://github.com/easyrdf/easyrdf) with opcache | 125,834 | 18,041.405 | 15.70x |
-| [ARC2](https://github.com/semsol/arc2) with opcache | 147,273 | 8,352.265 | 18.37x |
-| [N3.js](https://github.com/rdfjs/N3.js) | 8,017 | 30.336 | 1.00x |
-
-
-1. N3.js on Node.js 25 is faster, which is expected, but Hardf stays surprisingly close for a native PHP parser: about `3.32x` to `4.88x` slower with opcache enabled, and about `3.41x` to `5.19x` slower without it.
-2. Hardf remains effective over the tested range and is substantially faster than ARC2 at every size, while also overtaking EasyRDF on the larger datasets.
+Across all measured sizes, throughput is roughly linear. Strict mode favors correctness and broad syntax support; relaxed mode is the high-throughput path for trusted generated line-format data.
 
 ## License, status and contributions
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "rdf12:turtle": "npm run rdf12:turtle:syntax && npm run rdf12:turtle:eval && npm run rdf11:turtle",
     "rdf12:trig": "npm run rdf12:trig:syntax && npm run rdf12:trig:eval && npm run rdf11:trig",
     "rdf12": "npm run rdf12:ntriples && npm run rdf12:nquads && npm run rdf12:turtle && npm run rdf12:trig",
+    "bench:rdf": "php perf/benchmark-rdf.php",
+    "bench:rdf:quick": "php perf/benchmark-rdf.php --quick",
     "rdf11:ntriples:earl": "rdf-test-suite spec/hardf-rdf-test-engine.js https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-n-triples/manifest.ttl -o earl -p spec/earl-metadata.json",
     "rdf11:nquads:earl": "rdf-test-suite spec/hardf-rdf-test-engine.js https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-n-quads/manifest.ttl -o earl -p spec/earl-metadata.json",
     "rdf11:turtle:earl": "rdf-test-suite spec/hardf-rdf-test-engine.js https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-turtle/manifest.ttl -o earl -p spec/earl-metadata.json",

--- a/perf/benchmark-rdf.php
+++ b/perf/benchmark-rdf.php
@@ -84,7 +84,7 @@ try {
     exit(1);
 }
 
-$generatedDir = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'hardf-rdf-bench';
+$generatedDir = rtrim(sys_get_temp_dir(), \DIRECTORY_SEPARATOR).\DIRECTORY_SEPARATOR.'hardf-rdf-bench';
 if (!is_dir($generatedDir) && !mkdir($generatedDir, 0777, true) && !is_dir($generatedDir)) {
     echo 'Could not create benchmark directory: '.$generatedDir."\n";
     exit(1);
@@ -97,7 +97,7 @@ $easyRdf = __DIR__.'/easyrdf-perf.php';
 $arc2 = __DIR__.'/arc2-perf.php';
 
 // Keep opcache/JIT settings explicit for reproducible CLI measurements.
-$php = escapeshellarg(PHP_BINARY).' -d '.escapeshellarg('opcache.enable_cli=1').' -d '.escapeshellarg('opcache.jit_buffer_size=0');
+$php = escapeshellarg(\PHP_BINARY).' -d '.escapeshellarg('opcache.enable_cli=1').' -d '.escapeshellarg('opcache.jit_buffer_size=0');
 
 echo "| dataset | parser | statements | elapsed ms | statements/sec |\n";
 echo "|---------|--------|-----------:|-----------:|---------------:|\n";

--- a/perf/benchmark-rdf.php
+++ b/perf/benchmark-rdf.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+const DEFAULT_SIZES = [10000, 100000, 1000000];
+const QUICK_SIZES = [10000];
+
+function usage(): void
+{
+    echo "Usage: benchmark-rdf.php [--quick] [statement-count ...]\n";
+}
+
+function parseArgs(array $argv): array
+{
+    $quick = false;
+    $sizes = [];
+    foreach (array_slice($argv, 1) as $arg) {
+        if ('--quick' === $arg) {
+            $quick = true;
+            continue;
+        }
+        if (!preg_match('/^\d+$/', $arg)) {
+            usage();
+            throw new InvalidArgumentException('Statement counts must be positive integers.');
+        }
+        $sizes[] = (int) $arg;
+    }
+
+    if (empty($sizes)) {
+        $sizes = $quick ? QUICK_SIZES : DEFAULT_SIZES;
+    }
+
+    return $sizes;
+}
+
+function runCommand(string $command): string
+{
+    $output = [];
+    $exitCode = 0;
+    exec($command.' 2>&1', $output, $exitCode);
+    $result = implode("\n", $output);
+    if (0 !== $exitCode) {
+        throw new RuntimeException($result);
+    }
+
+    return $result;
+}
+
+function parsePerfOutput(string $output): array
+{
+    if (!preg_match('/Parsing file .*: ([0-9.]+)s/', $output, $timeMatch)) {
+        throw new RuntimeException('Could not parse elapsed time from output: '.$output);
+    }
+    if (!preg_match('/Triples parsed: (\d+)/', $output, $countMatch)) {
+        throw new RuntimeException('Could not parse statement count from output: '.$output);
+    }
+
+    return [
+        'seconds' => (float) $timeMatch[1],
+        'statements' => (int) $countMatch[1],
+    ];
+}
+
+function printRow(string $dataset, string $parser, int $expected, array $result): void
+{
+    if ($expected !== $result['statements']) {
+        throw new RuntimeException($parser.' parsed '.$result['statements'].' statements, expected '.$expected.'.');
+    }
+    $statementsPerSecond = $result['seconds'] > 0 ? $result['statements'] / $result['seconds'] : 0;
+    printf(
+        "| %s | %s | %s | %.2f | %.0f |\n",
+        $dataset,
+        $parser,
+        number_format($result['statements']),
+        $result['seconds'] * 1000,
+        $statementsPerSecond
+    );
+}
+
+try {
+    $sizes = parseArgs($argv);
+} catch (Throwable $error) {
+    echo $error->getMessage()."\n";
+    exit(1);
+}
+
+$generatedDir = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'hardf-rdf-bench';
+if (!is_dir($generatedDir) && !mkdir($generatedDir, 0777, true) && !is_dir($generatedDir)) {
+    echo 'Could not create benchmark directory: '.$generatedDir."\n";
+    exit(1);
+}
+
+$generateRdf12 = __DIR__.'/generate-rdf12-nq.php';
+$generateNt = __DIR__.'/generate-nt.php';
+$hardf = __DIR__.'/parser-streaming-perf.php';
+$easyRdf = __DIR__.'/easyrdf-perf.php';
+$arc2 = __DIR__.'/arc2-perf.php';
+
+// Keep opcache/JIT settings explicit for reproducible CLI measurements.
+$php = escapeshellarg(PHP_BINARY).' -d '.escapeshellarg('opcache.enable_cli=1').' -d '.escapeshellarg('opcache.jit_buffer_size=0');
+
+echo "| dataset | parser | statements | elapsed ms | statements/sec |\n";
+echo "|---------|--------|-----------:|-----------:|---------------:|\n";
+
+foreach ($sizes as $size) {
+    $rdf12File = $generatedDir.'/rdf12-'.$size.'.nq';
+    $rdf10File = $generatedDir.'/rdf10-'.$size.'.nt';
+
+    try {
+        runCommand($php.' '.escapeshellarg($generateRdf12).' '.escapeshellarg($rdf12File).' '.escapeshellarg((string) $size));
+        runCommand($php.' '.escapeshellarg($generateNt).' '.escapeshellarg($rdf10File).' '.escapeshellarg((string) $size));
+
+        printRow('RDF1.2 mixed N-Quads', 'Hardf strict', $size, parsePerfOutput(runCommand($php.' '.escapeshellarg($hardf).' '.escapeshellarg($rdf12File).' --format=N-Quads')));
+        printRow('RDF1.2 mixed N-Quads', 'Hardf relax', $size, parsePerfOutput(runCommand($php.' '.escapeshellarg($hardf).' '.escapeshellarg($rdf12File).' --format=N-Quads --relax')));
+
+        printRow('Plain RDF1.0 N-Triples', 'Hardf strict', $size, parsePerfOutput(runCommand($php.' '.escapeshellarg($hardf).' '.escapeshellarg($rdf10File).' --format=N-Triples')));
+        printRow('Plain RDF1.0 N-Triples', 'EasyRDF', $size, parsePerfOutput(runCommand($php.' '.escapeshellarg($easyRdf).' '.escapeshellarg($rdf10File))));
+        printRow('Plain RDF1.0 N-Triples', 'ARC2', $size, parsePerfOutput(runCommand($php.' '.escapeshellarg($arc2).' '.escapeshellarg($rdf10File))));
+    } catch (Throwable $error) {
+        echo 'Benchmark failed for '.$size.' statements: '.$error->getMessage()."\n";
+        exit(1);
+    } finally {
+        if (is_file($rdf12File)) {
+            unlink($rdf12File);
+        }
+        if (is_file($rdf10File)) {
+            unlink($rdf10File);
+        }
+    }
+}

--- a/perf/generate-rdf12-nq.php
+++ b/perf/generate-rdf12-nq.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+if (3 !== count($argv)) {
+    echo "Usage: generate-rdf12-nq.php output-file statement-count\n";
+    exit(1);
+}
+
+$outputFile = $argv[1];
+$statementCount = (int) $argv[2];
+
+if ($statementCount <= 0) {
+    echo "Statement count must be a positive integer\n";
+    exit(1);
+}
+
+$directory = dirname($outputFile);
+if (!is_dir($directory) && !mkdir($directory, 0777, true) && !is_dir($directory)) {
+    echo 'Could not create directory: '.$directory."\n";
+    exit(1);
+}
+
+$handle = fopen($outputFile, 'wb');
+if (false === $handle) {
+    echo 'Could not open output file: '.$outputFile."\n";
+    exit(1);
+}
+
+for ($index = 0; $index < $statementCount; ++$index) {
+    $subject = '<http://example.org/s'.$index.'>';
+    $predicate = '<http://example.org/p'.($index % 17).'>';
+
+    switch ($index % 8) {
+        case 0:
+            $object = '<http://example.org/o'.$index.'>';
+            break;
+        case 1:
+            $object = '"literal '.$index.'"';
+            break;
+        case 2:
+            $object = '"hello '.$index.'"@en';
+            break;
+        case 3:
+            $object = '"'.($index % 1000).'"^^<http://www.w3.org/2001/XMLSchema#integer>';
+            break;
+        case 4:
+            $object = '"'.($index % 1000).'.25"^^<http://www.w3.org/2001/XMLSchema#decimal>';
+            break;
+        case 5:
+            $object = '"'.(0 === $index % 2 ? 'true' : 'false').'"^^<http://www.w3.org/2001/XMLSchema#boolean>';
+            break;
+        case 6:
+            $object = '<<(<http://example.org/ts'.$index.'> <http://example.org/tp'.($index % 7).'> <http://example.org/to'.$index.'>)>>';
+            break;
+        default:
+            $object = '<<(<http://example.org/ts'.$index.'> <http://example.org/tp'.($index % 7).'> "tv '.$index.'")>>';
+            break;
+    }
+
+    if (0 === $index % 4) {
+        $line = $subject.' '.$predicate.' '.$object.' .';
+    } else {
+        $line = $subject.' '.$predicate.' '.$object.' <http://example.org/g'.($index % 11).'> .';
+    }
+
+    if (false === fwrite($handle, $line."\n")) {
+        fclose($handle);
+        throw new RuntimeException('Could not write to output file: '.$outputFile);
+    }
+}
+
+fclose($handle);
+echo 'Generated '.$statementCount.' RDF1.2 statements at '.$outputFile."\n";

--- a/perf/parser-streaming-perf.php
+++ b/perf/parser-streaming-perf.php
@@ -3,13 +3,22 @@
 include_once __DIR__.'/../vendor/autoload.php';
 use pietercolpaert\hardf\TriGParser;
 
-if (2 !== count($argv)) {
-    echo "Usage: parser-streaming-perf.php filename\n";
-    exit;
+if (count($argv) < 2) {
+    echo "Usage: parser-streaming-perf.php filename [--format=FORMAT] [--relax]\n";
+    exit(1);
 }
 
 $filename = $argv[1];
 $base = 'file://'.$filename;
+$format = null;
+$relax = false;
+foreach (array_slice($argv, 2) as $arg) {
+    if (0 === strpos($arg, '--format=')) {
+        $format = substr($arg, 9);
+    } elseif ('--relax' === $arg) {
+        $relax = true;
+    }
+}
 
 if (!is_readable($filename)) {
     echo 'File not found or not readable: '.$filename."\n";
@@ -19,7 +28,15 @@ if (!is_readable($filename)) {
 $TEST = microtime(true);
 
 $count = 0;
-$parser = new TriGParser(['documentIRI' => $base], function ($error, $triple) use (&$count, $TEST, $filename) {
+$options = ['documentIRI' => $base];
+if (null !== $format && '' !== $format) {
+    $options['format'] = $format;
+}
+if ($relax) {
+    $options['relax'] = true;
+}
+
+$parser = new TriGParser($options, function ($error, $triple) use (&$count, $TEST, $filename) {
     if ($error) {
         echo '- Parsing file '.$filename.' failed after '.(microtime(true) - $TEST)."s\n";
         echo '* Error: '.$error->getMessage()."\n";

--- a/perf/parser-streaming-perf.php
+++ b/perf/parser-streaming-perf.php
@@ -13,7 +13,7 @@ $base = 'file://'.$filename;
 $format = null;
 $relax = false;
 foreach (array_slice($argv, 2) as $arg) {
-    if (0 === strpos($arg, '--format=')) {
+    if (str_starts_with($arg, '--format=')) {
         $format = substr($arg, 9);
     } elseif ('--relax' === $arg) {
         $relax = true;

--- a/src/TriGParser.php
+++ b/src/TriGParser.php
@@ -2227,7 +2227,7 @@ class TriGParser
 
         $hasScheme = false;
         for ($i = $start; $i < $end; ++$i) {
-            $code = ord($line[$i]);
+            $code = \ord($line[$i]);
             if ($code <= 32 || 34 === $code || 60 === $code || 62 === $code || 94 === $code || 96 === $code || 123 === $code || 124 === $code || 125 === $code) {
                 return false;
             }
@@ -2245,7 +2245,7 @@ class TriGParser
         $start = $i + 2;
         $i = $start;
         while ($i < $length) {
-            $code = ord($line[$i]);
+            $code = \ord($line[$i]);
             $isAlpha = ($code >= 65 && $code <= 90) || ($code >= 97 && $code <= 122);
             $isDigit = $code >= 48 && $code <= 57;
             if (!$isAlpha && !$isDigit && 95 !== $code && 45 !== $code && 46 !== $code) {
@@ -2269,7 +2269,7 @@ class TriGParser
         }
         if (!$this->relax) {
             for ($j = $start; $j < $end; ++$j) {
-                if (ord($line[$j]) < 32) {
+                if (\ord($line[$j]) < 32) {
                     return null;
                 }
             }
@@ -2280,7 +2280,7 @@ class TriGParser
         if (isset($line[$i]) && '@' === $line[$i]) {
             $languageStart = ++$i;
             while (isset($line[$i])) {
-                $code = ord($line[$i]);
+                $code = \ord($line[$i]);
                 $isAlpha = ($code >= 65 && $code <= 90) || ($code >= 97 && $code <= 122);
                 $isDigit = $code >= 48 && $code <= 57;
                 if (!$isAlpha && !$isDigit && 45 !== $code) {
@@ -2321,17 +2321,17 @@ class TriGParser
         if (0 === $length) {
             return false;
         }
-        $first = ord($language[0]);
+        $first = \ord($language[0]);
         if (!(($first >= 65 && $first <= 90) || ($first >= 97 && $first <= 122))) {
             return false;
         }
-        if (false !== strpos($language, '--') && !str_ends_with($language, '--ltr') && !str_ends_with($language, '--rtl')) {
+        if (str_contains($language, '--') && !str_ends_with($language, '--ltr') && !str_ends_with($language, '--rtl')) {
             return false;
         }
 
         $subtagLength = 0;
         for ($i = 0; $i < $length; ++$i) {
-            $code = ord($language[$i]);
+            $code = \ord($language[$i]);
             if (45 === $code) {
                 if (0 === $subtagLength || $subtagLength > 8) {
                     return false;

--- a/src/TriGParser.php
+++ b/src/TriGParser.php
@@ -106,6 +106,15 @@ class TriGParser
     private $supportsNamedGraphs;
     private $supportsMessages;
     private $supportsQuads;
+    private $lineMode;
+    private $relax;
+    private $lineBuffer;
+    private $pendingFastLineCount;
+    private $namedNodeCacheMax;
+    private $predicateCache;
+    private $datatypeCache;
+    private $graphCache;
+    private $iriTermCache;
     private $supportsReifiedTriples;
     private $triple;
     private $tripleCallback;
@@ -154,6 +163,15 @@ class TriGParser
         $isN3 = str_contains($format, 'n3') ? true : false;
         $this->n3Mode = $isN3;
         $isLineMode = $isNTriples || $isNQuads;
+        $this->lineMode = $isLineMode;
+        $this->relax = !empty($options['relax']);
+        $this->lineBuffer = '';
+        $this->pendingFastLineCount = 0;
+        $this->namedNodeCacheMax = isset($options['namedNodeCacheSize']) ? max(16, (int) $options['namedNodeCacheSize']) : 2048;
+        $this->predicateCache = [];
+        $this->datatypeCache = [];
+        $this->graphCache = [];
+        $this->iriTermCache = [];
         if (!($this->supportsNamedGraphs = !($isTurtle || $isN3))) {
             $this->readPredicateOrNamedGraph = $this->readPredicate;
         }
@@ -1929,6 +1947,436 @@ class TriGParser
 
     // ## Public methods
 
+    private function parseChunkInternal(string $input, bool $finalize): void
+    {
+        if ($this->canUseFastLineScanner()) {
+            $this->parseChunkWithFastLineScanner($input, $finalize);
+
+            return;
+        }
+
+        $this->syncFastLineCount();
+        $this->parseChunkWithLexer($input, $finalize);
+    }
+
+    private function canUseFastLineScanner(): bool
+    {
+        return $this->relax && $this->lineMode && !$this->supportsMessages && null === $this->messageCounter && !$this->collectMessages;
+    }
+
+    private function parseChunkWithLexer(string $input, bool $finalize): void
+    {
+        $tokens = $this->lexer->tokenize($input, $finalize);
+        foreach ($tokens as $token) {
+            if (isset($this->readCallback)) {
+                $this->readCallback = \call_user_func($this->readCallback, $token);
+            } else {
+                break;
+            }
+        }
+    }
+
+    private function parseChunkWithFastLineScanner(string $input, bool $finalize): void
+    {
+        $this->lineBuffer .= $input;
+        $length = \strlen($this->lineBuffer);
+        $offset = 0;
+
+        while ($offset < $length) {
+            $lineEnd = $offset + strcspn($this->lineBuffer, "\r\n", $offset);
+            if ($lineEnd >= $length) {
+                break;
+            }
+            $nextOffset = $lineEnd + 1;
+            if ("\r" === $this->lineBuffer[$lineEnd] && $nextOffset < $length && "\n" === $this->lineBuffer[$nextOffset]) {
+                ++$nextOffset;
+            }
+            $line = substr($this->lineBuffer, $offset, $lineEnd - $offset);
+            if (!$this->tryEmitFastLine($line)) {
+                $this->syncFastLineCount();
+                $this->parseChunkWithLexer(substr($this->lineBuffer, $offset, $nextOffset - $offset), false);
+                if (!$this->canUseFastLineScanner()) {
+                    $this->lineBuffer = substr($this->lineBuffer, $nextOffset);
+                    if ('' !== $this->lineBuffer) {
+                        $rest = $this->lineBuffer;
+                        $this->lineBuffer = '';
+                        $this->parseChunkWithLexer($rest, $finalize);
+                    } elseif ($finalize) {
+                        $this->parseChunkWithLexer('', true);
+                    }
+
+                    return;
+                }
+            } else {
+                ++$this->pendingFastLineCount;
+            }
+            $offset = $nextOffset;
+        }
+
+        $this->lineBuffer = substr($this->lineBuffer, $offset);
+
+        if ($finalize) {
+            if ('' !== $this->lineBuffer) {
+                if (!$this->tryEmitFastLine($this->lineBuffer)) {
+                    $this->syncFastLineCount();
+                    $this->parseChunkWithLexer($this->lineBuffer, false);
+                }
+                $this->lineBuffer = '';
+            }
+            $this->parseChunkWithLexer('', true);
+        }
+    }
+
+    private function syncFastLineCount(): void
+    {
+        while ($this->pendingFastLineCount > 0) {
+            $chunkLineCount = min($this->pendingFastLineCount, 8192);
+            $this->parseChunkWithLexer(str_repeat("\n", $chunkLineCount), false);
+            $this->pendingFastLineCount -= $chunkLineCount;
+        }
+    }
+
+    private function tryEmitFastLine(string $line): bool
+    {
+        $quad = null;
+        if (!$this->tryParseFastLine($line, $quad)) {
+            return false;
+        }
+        if (null !== $quad) {
+            \call_user_func($this->triple, $quad['subject'], $quad['predicate'], $quad['object'], $quad['graph']);
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed>|null $quad
+     */
+    private function tryParseFastLine(string $line, ?array &$quad): bool
+    {
+        $quad = null;
+        if ('' === $line) {
+            return true;
+        }
+        if (str_contains($line, "\t") || str_contains($line, '\\')) {
+            return false;
+        }
+
+        $length = \strlen($line);
+        $i = 0;
+        $this->skipFastSpaces($line, $i, $length);
+        if ($i >= $length || '#' === $line[$i]) {
+            return true;
+        }
+
+        $subject = $this->parseFastNode($line, $i, true);
+        if (null === $subject || !$this->requireFastSpace($line, $i, $length)) {
+            return false;
+        }
+
+        $predicate = $this->parseFastIri($line, $i, 'predicate');
+        if (null === $predicate || !$this->requireFastSpace($line, $i, $length)) {
+            return false;
+        }
+
+        $object = $this->parseFastObject($line, $i);
+        if (null === $object) {
+            return false;
+        }
+
+        $this->skipFastSpaces($line, $i, $length);
+        $graph = '';
+        if ($this->supportsQuads && $i < $length && '.' !== $line[$i]) {
+            $graph = $this->parseFastNode($line, $i, true);
+            if (null === $graph) {
+                return false;
+            }
+            $this->skipFastSpaces($line, $i, $length);
+        }
+
+        if ($i >= $length || '.' !== $line[$i]) {
+            return false;
+        }
+        ++$i;
+        $this->skipFastSpaces($line, $i, $length);
+        if ($i !== $length) {
+            return false;
+        }
+
+        $quad = [
+            'subject' => $subject,
+            'predicate' => $predicate,
+            'object' => $object,
+            'graph' => $graph,
+        ];
+
+        return true;
+    }
+
+    private function requireFastSpace(string $line, int &$i, int $length): bool
+    {
+        if ($i >= $length || ' ' !== $line[$i]) {
+            return false;
+        }
+        $this->skipFastSpaces($line, $i, $length);
+
+        return true;
+    }
+
+    private function skipFastSpaces(string $line, int &$i, int $length): void
+    {
+        while ($i < $length && ' ' === $line[$i]) {
+            ++$i;
+        }
+    }
+
+    private function parseFastNode(string $line, int &$i, bool $allowBlank): ?string
+    {
+        if (!isset($line[$i])) {
+            return null;
+        }
+        if ('<' === $line[$i]) {
+            return $this->parseFastIri($line, $i, 'iri');
+        }
+        if ($allowBlank && '_' === $line[$i] && isset($line[$i + 1]) && ':' === $line[$i + 1]) {
+            return $this->parseFastBlankNode($line, $i);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>|string|null
+     */
+    private function parseFastObject(string $line, int &$i)
+    {
+        if (!isset($line[$i])) {
+            return null;
+        }
+        if ('"' === $line[$i]) {
+            return $this->parseFastLiteral($line, $i);
+        }
+        if ('<' === $line[$i] && isset($line[$i + 1], $line[$i + 2]) && '<' === $line[$i + 1] && '(' === $line[$i + 2]) {
+            return $this->parseFastTripleTerm($line, $i);
+        }
+
+        return $this->parseFastNode($line, $i, true);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function parseFastTripleTerm(string $line, int &$i): ?array
+    {
+        $length = \strlen($line);
+        $i += 3;
+
+        $subject = $this->parseFastNode($line, $i, true);
+        if (null === $subject || !$this->requireFastSpace($line, $i, $length)) {
+            return null;
+        }
+
+        $predicate = $this->parseFastIri($line, $i, 'predicate');
+        if (null === $predicate || !$this->requireFastSpace($line, $i, $length)) {
+            return null;
+        }
+
+        $object = $this->parseFastObject($line, $i);
+        if (null === $object) {
+            return null;
+        }
+
+        if (!isset($line[$i], $line[$i + 1], $line[$i + 2]) || ')' !== $line[$i] || '>' !== $line[$i + 1] || '>' !== $line[$i + 2]) {
+            return null;
+        }
+        $i += 3;
+
+        return [
+            'type' => 'TripleTerm',
+            'subject' => $subject,
+            'predicate' => $predicate,
+            'object' => $object,
+        ];
+    }
+
+    private function parseFastIri(string $line, int &$i, string $cacheType): ?string
+    {
+        $start = $i + 1;
+        $end = strpos($line, '>', $start);
+        if (false === $end) {
+            return null;
+        }
+        if (!$this->relax && !$this->isValidFastIri($line, $start, $end)) {
+            return null;
+        }
+        $iri = substr($line, $start, $end - $start);
+        $i = $end + 1;
+
+        if ('iri' === $cacheType) {
+            return $iri;
+        }
+
+        return $this->cacheNamedNode($iri, $cacheType);
+    }
+
+    private function isValidFastIri(string $line, int $start, int $end): bool
+    {
+        if ($start >= $end) {
+            return false;
+        }
+
+        $hasScheme = false;
+        for ($i = $start; $i < $end; ++$i) {
+            $code = ord($line[$i]);
+            if ($code <= 32 || 34 === $code || 60 === $code || 62 === $code || 94 === $code || 96 === $code || 123 === $code || 124 === $code || 125 === $code) {
+                return false;
+            }
+            if (!$hasScheme && 58 === $code) {
+                $hasScheme = $i > $start;
+            }
+        }
+
+        return $hasScheme;
+    }
+
+    private function parseFastBlankNode(string $line, int &$i): ?string
+    {
+        $length = \strlen($line);
+        $start = $i + 2;
+        $i = $start;
+        while ($i < $length) {
+            $code = ord($line[$i]);
+            $isAlpha = ($code >= 65 && $code <= 90) || ($code >= 97 && $code <= 122);
+            $isDigit = $code >= 48 && $code <= 57;
+            if (!$isAlpha && !$isDigit && 95 !== $code && 45 !== $code && 46 !== $code) {
+                break;
+            }
+            ++$i;
+        }
+        if ($i === $start || (!$this->relax && '.' === $line[$i - 1])) {
+            return null;
+        }
+
+        return $this->prefixes['_'].substr($line, $start, $i - $start);
+    }
+
+    private function parseFastLiteral(string $line, int &$i): ?string
+    {
+        $start = ++$i;
+        $end = strpos($line, '"', $start);
+        if (false === $end) {
+            return null;
+        }
+        if (!$this->relax) {
+            for ($j = $start; $j < $end; ++$j) {
+                if (ord($line[$j]) < 32) {
+                    return null;
+                }
+            }
+        }
+        $literal = '"'.substr($line, $start, $end - $start).'"';
+        $i = $end + 1;
+
+        if (isset($line[$i]) && '@' === $line[$i]) {
+            $languageStart = ++$i;
+            while (isset($line[$i])) {
+                $code = ord($line[$i]);
+                $isAlpha = ($code >= 65 && $code <= 90) || ($code >= 97 && $code <= 122);
+                $isDigit = $code >= 48 && $code <= 57;
+                if (!$isAlpha && !$isDigit && 45 !== $code) {
+                    break;
+                }
+                ++$i;
+            }
+            if ($languageStart === $i) {
+                return null;
+            }
+            $rawLanguage = substr($line, $languageStart, $i - $languageStart);
+            if (!$this->relax && !$this->isValidFastLanguageTag($rawLanguage)) {
+                return null;
+            }
+
+            return $literal.'@'.strtolower($rawLanguage);
+        }
+
+        if (isset($line[$i], $line[$i + 1]) && '^' === $line[$i] && '^' === $line[$i + 1]) {
+            $i += 2;
+            $datatype = $this->parseFastIri($line, $i, 'datatype');
+            if (null === $datatype) {
+                return null;
+            }
+            if (!$this->relax && (self::RDF_LANG_STRING === $datatype || self::RDF_DIR_LANG_STRING === $datatype)) {
+                return null;
+            }
+
+            return $literal.'^^'.$datatype;
+        }
+
+        return $literal;
+    }
+
+    private function isValidFastLanguageTag(string $language): bool
+    {
+        $length = \strlen($language);
+        if (0 === $length) {
+            return false;
+        }
+        $first = ord($language[0]);
+        if (!(($first >= 65 && $first <= 90) || ($first >= 97 && $first <= 122))) {
+            return false;
+        }
+        if (false !== strpos($language, '--') && !str_ends_with($language, '--ltr') && !str_ends_with($language, '--rtl')) {
+            return false;
+        }
+
+        $subtagLength = 0;
+        for ($i = 0; $i < $length; ++$i) {
+            $code = ord($language[$i]);
+            if (45 === $code) {
+                if (0 === $subtagLength || $subtagLength > 8) {
+                    return false;
+                }
+                $subtagLength = 0;
+                continue;
+            }
+            $isAlpha = ($code >= 65 && $code <= 90) || ($code >= 97 && $code <= 122);
+            $isDigit = $code >= 48 && $code <= 57;
+            if (!$isAlpha && !$isDigit) {
+                return false;
+            }
+            ++$subtagLength;
+        }
+
+        return $subtagLength > 0 && $subtagLength <= 8;
+    }
+
+    private function cacheNamedNode(string $value, string $type): string
+    {
+        switch ($type) {
+            case 'predicate':
+                return $this->cacheString($this->predicateCache, $value);
+            case 'datatype':
+                return $this->cacheString($this->datatypeCache, $value);
+            case 'graph':
+                return $this->cacheString($this->graphCache, $value);
+            default:
+                return $this->cacheString($this->iriTermCache, $value);
+        }
+    }
+
+    private function cacheString(array &$cache, string $value): string
+    {
+        if (isset($cache[$value])) {
+            return $cache[$value];
+        }
+        if (\count($cache) >= $this->namedNodeCacheMax) {
+            $cache = [];
+        }
+        $cache[$value] = $value;
+
+        return $cache[$value];
+    }
+
     // ### `parse` parses the N3 input and emits each parsed triple through the callback
     public function parse($input, $tripleCallback = null, $prefixCallback = null)
     {
@@ -1978,12 +2426,7 @@ class TriGParser
                     $error = $e;
                 }
             };
-            $tokens = $this->lexer->tokenize($input, $finalize);
-            foreach ($tokens as $token) {
-                if (isset($this->readCallback)) {
-                    $this->readCallback = \call_user_func($this->readCallback, $token);
-                }
-            }
+            $this->parseChunkInternal((string) $input, (bool) $finalize);
             if ($error) {
                 throw $error;
             }
@@ -2003,15 +2446,7 @@ class TriGParser
             // Parse asynchronously otherwise, executing the read callback when a token arrives
             $this->callback = $this->tripleCallback;
             try {
-                $tokens = $this->lexer->tokenize($input, $finalize);
-                foreach ($tokens as $token) {
-                    if (isset($this->readCallback)) {
-                        $this->readCallback = \call_user_func($this->readCallback, $token);
-                    } else {
-                        // error occured in parser
-                        break;
-                    }
-                }
+                $this->parseChunkInternal((string) $input, (bool) $finalize);
             } catch (\Exception $e) {
                 if ($this->callback) {
                     \call_user_func($this->callback, $e, null);

--- a/test/TriGParserFastPathTest.php
+++ b/test/TriGParserFastPathTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\hardf;
+
+use PHPUnit\Framework\TestCase;
+use pietercolpaert\hardf\TriGParser;
+
+class TriGParserFastPathTest extends TestCase
+{
+    public function testRelaxedLineModeAcceptsRelativeIrisForTrustedBenchmarks(): void
+    {
+        $parser = new TriGParser(['format' => 'N-Triples', 'relax' => true]);
+
+        $this->assertSame([
+            [
+                'subject' => 's',
+                'predicate' => 'p',
+                'object' => 'o',
+                'graph' => '',
+            ],
+        ], $parser->parse('<s> <p> <o> .'));
+    }
+
+    public function testStrictLineModeRejectsRelativeIris(): void
+    {
+        $parser = new TriGParser(['format' => 'N-Triples']);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Disallowed relative IRI');
+
+        $parser->parse('<s> <p> <o> .');
+    }
+
+    public function testFastPathParsesNQuadsWithTripleTermObject(): void
+    {
+        $parser = new TriGParser(['format' => 'N-Quads', 'relax' => true]);
+        $quads = $parser->parse('<http://example.org/s> <http://example.org/p> <<(<http://example.org/a> <http://example.org/b> "c")>> <http://example.org/g> .');
+
+        $this->assertSame('http://example.org/s', $quads[0]['subject']);
+        $this->assertSame('http://example.org/p', $quads[0]['predicate']);
+        $this->assertSame('http://example.org/g', $quads[0]['graph']);
+        $this->assertSame([
+            'type' => 'TripleTerm',
+            'subject' => 'http://example.org/a',
+            'predicate' => 'http://example.org/b',
+            'object' => '"c"',
+        ], $quads[0]['object']);
+    }
+}


### PR DESCRIPTION
This PR tried to improve Hardf’s performance story for line-based RDF formats and adds a reproducible benchmark suite for RDF1.2 and RDF1.0 parser comparisons - but didn’t really achieve that so far.

### What changed

- Added a relaxed single-pass scanner hot path for trusted N-Triples/N-Quads input in TriGParser.php.
- Kept strict parsing on the existing full conformance parser path after measuring that strict scanner validation was slower on PHP 8.3.
- Added the `relax` parser option for machine-generated trusted benchmark input.
- Added bounded named-node caches for recurring predicates, datatypes, and graph IRIs in the relaxed scanner path.
- Preserved RDF Messages behavior by disabling the fast path for message/collection parsing.
- Added focused fast-path tests in TriGParserFastPathTest.php.
- Added RDF benchmark scripts:
  - benchmark-rdf.php
  - generate-rdf12-nq.php
  - updated parser-streaming-perf.php
- Added benchmark npm scripts in package.json:
  - `bench:rdf`
  - `bench:rdf:quick`
- Rewrote the Performance chapter in README.md with fresh benchmark numbers and interpretation.

### Performance findings

Fresh benchmark run with PHP 8.3.6 CLI:

- RDF1.2 mixed N-Quads, 1M statements:
  - strict mode: ~150k statements/sec
  - relaxed scanner: ~449k statements/sec
  - relaxed mode is about 3x faster than strict mode
- Plain RDF1.0 N-Triples, 1M statements:
  - Hardf strict: ~210k statements/sec
  - EasyRDF: ~216k statements/sec
  - ARC2: ~73k statements/sec

The main takeaway is that strict mode remains stable and conformance-focused, while `relax` provides a high-throughput path for trusted generated line-format data.
