### PR TITLE
Replace easyrdf/easyrdf with sweetrdf/easyrdf in require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require-dev" : {
         "friendsofphp/php-cs-fixer": "*",
         "phpunit/phpunit": "^7 || ^8 || ^9",
-        "easyrdf/easyrdf": "^1.1",
+        "sweetrdf/easyrdf": "^1.19",
         "semsol/arc2": "^3.1",
         "phpstan/phpstan": "^2.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require-dev" : {
         "friendsofphp/php-cs-fixer": "*",
         "phpunit/phpunit": "^7 || ^8 || ^9",
-        "sweetrdf/easyrdf": "^1.19",
+        "sweetrdf/easyrdf": "^1.1",
         "semsol/arc2": "^3.1",
         "phpstan/phpstan": "^2.2"
     },


### PR DESCRIPTION
I maintain the EasyRdf fork https://github.com/sweetrdf/easyrdf, so we can be sure to always have a version which runs on the latest PHP versions. It also should support PHP 7.1+.